### PR TITLE
Fix old C version of CLEVER/is_prime1/Neq

### DIFF
--- a/benchmarks/CLEVER/is_prime1/Neq/oldV.c
+++ b/benchmarks/CLEVER/is_prime1/Neq/oldV.c
@@ -7,7 +7,7 @@ int lib(unsigned int x, int b) {
     for (int i = 0; i < NUMPRIMES; i++) {
       int mod = x % primes[i];
       if (mod == 0)
-        return x == primes[i];
+        return 0;
     }
   }
   return 1;


### PR DESCRIPTION
The old and new C version of CLEVER/is_prime1/Neq was the same causing wrong evaluation by programs.
This PR fixes the old C version according to the old Java version.