### PR TITLE
Fix compilation and function/method name

### DIFF
--- a/benchmarks/CLEVER/multiple/Eq/C-Desc.json
+++ b/benchmarks/CLEVER/multiple/Eq/C-Desc.json
@@ -1,7 +1,7 @@
 {
   "benchmark name": "CLEVER",
   "program name": "multiple.client",
-  "function name": "iib",
+  "function name": "lib",
   "LOC":11,
   "# Loops":0,
   "# non-linear arithmetics":3,

--- a/benchmarks/REVE/average/Eq/C-Desc.json
+++ b/benchmarks/REVE/average/Eq/C-Desc.json
@@ -1,7 +1,7 @@
 {
   "benchmark name": "REVE",
   "program name": "average",
-  "function name": "f",
+  "function name": "average",
   "LOC":11,
   "# Loops":1,
   "# non-linear arithmetics":1,

--- a/benchmarks/REVE/average/Eq/J-Desc.json
+++ b/benchmarks/REVE/average/Eq/J-Desc.json
@@ -1,7 +1,7 @@
 {
   "benchmark name": "REVE",
   "program name": "average",
-  "method name": "f",
+  "method name": "average",
   "LOC":11,
   "# Loops":1,
   "# non-linear arithmetics":1,

--- a/benchmarks/REVE/triangular/Eq/C-Desc.json
+++ b/benchmarks/REVE/triangular/Eq/C-Desc.json
@@ -1,7 +1,7 @@
 {
   "benchmark name": "REVE",
   "program name": "triangular.triangle",
-  "function name": "f",
+  "function name": "g",
   "LOC":15,
   "# Loops":0,
   "# non-linear arithmetics":0,

--- a/benchmarks/REVE/triangular/Eq/J-Desc.json
+++ b/benchmarks/REVE/triangular/Eq/J-Desc.json
@@ -1,7 +1,7 @@
 {
   "benchmark name": "REVE",
   "program name": "triangular.triangle",
-  "method name": "f",
+  "method name": "g",
   "LOC":15,
   "# Loops":0,
   "# non-linear arithmetics":0,

--- a/benchmarks/ej_hash/testCollision2/Eq/C-Desc.json
+++ b/benchmarks/ej_hash/testCollision2/Eq/C-Desc.json
@@ -8,17 +8,17 @@
   "changes": 
   [
     {
-      "change line": 24,
+      "change line": 28,
       "change type": "Update", 
       "change operation": "Decompose Condition" 
     },
     {
-      "change line": 28,
+      "change line": 32,
       "change type": "Insert", 
       "change operation": "New method" 
     },
     {
-      "change line": 29,
+      "change line": 33,
       "change type": "Insert", 
       "change operation": "New method" 
     }

--- a/benchmarks/ej_hash/testCollision2/Eq/newV.c
+++ b/benchmarks/ej_hash/testCollision2/Eq/newV.c
@@ -1,10 +1,14 @@
 #include <stdio.h>
 #include <stdbool.h>
+
 typedef struct newV {
     int x;
     long y;
     int z;
 }ejhash;
+
+bool checkCond(ejhash o1, ejhash o2);
+
 ejhash constructor(int x, long y, int z) {
 		ejhash obj;
 	    obj.x = x;


### PR DESCRIPTION
I discovered a few problems:
- one C file was not able to compile because a function was used there before its definition,
- a few wrong function/method names in `C-Desc.json`/`J-Desc.json` files.