### PR TITLE
Fix typo in benchmarks/gam/gammq/Eq/newV.c

### DIFF
--- a/benchmarks/gam/gammq/Eq/newV.c
+++ b/benchmarks/gam/gammq/Eq/newV.c
@@ -9,7 +9,7 @@ double snippet (double a, double x, double gamser, double gammcf, double gln) {
     if (x < 0.0)//change
       return -100000;
     if (a <= 0.0)//change
-      return -1000;
+      return -100000;
     if (x < a+1.0) {
       gamser =gser(a,x,gln, gamser);
       return 1.0-gamser;


### PR DESCRIPTION
This PR fixes a typo in the file `benchmarks/gam/gammq/Eq/newV.c`, according to old version and Java version the return value should contain more zeros.