### PR TITLE
Fix the ell/ellpi/Eq benchmark

### DIFF
--- a/benchmarks/ell/ellpi/Eq/newV.c
+++ b/benchmarks/ell/ellpi/Eq/newV.c
@@ -16,7 +16,7 @@ double snippet (double phi, double en, double ak){
     s=sin(phi);
     enss=en*s*s;
     cc=SQR(cos(phi));
-    q=1.0+((s*ak)*(s*ak));//change
+    q=1.0-((s*ak)*(s*ak));//change
     return s*(rf(cc,q,1.0)-enss*rj(cc,q,1.0,1.0+enss)/3.0);
   }
 double SQR(double a) {


### PR DESCRIPTION
The benchmark aims to use the mathematical law for simplification of an expression (A+B)*(A-B) to A^2 - B^2, however it currently modifies the program to A^2 + B^2 which is clearly incorrect. The semantic difference can be reproduced e.g. by calling snippet(30.0, 1, 2.0).

Fixes: #7 (more info about reproducer also there)